### PR TITLE
Create de_de.json

### DIFF
--- a/src/main/resources/assets/mysticalchemy/lang/de_de.json
+++ b/src/main/resources/assets/mysticalchemy/lang/de_de.json
@@ -1,0 +1,10 @@
+{
+	"block.mysticalchemy.crucible": "Braukessel",
+	"item.mysticalchemy.concoction": "Mystisches Gebräu",
+	"item.mysticalchemy.crucible_spoon": "Rührlöffel",
+	"item.mysticalchemy.simple_sampling_kit": "Einfaches Probenahme-Kit",
+	"item.mysticalchemy.advanced_sampling_kit": "Fortgeschrittenes Probenahme-Kit",	
+	
+	"chat.mysticalchemy.no_effects": "Es gibt keine Effekte in diesem Trank.",
+	"chat.mysticalchemy.format_effect": "%s: %s"
+}


### PR DESCRIPTION
This is the most I can do; this are by no means litteral translations as crucible means `tiegel` in german, which would be used in smeltery. As such I used the word for Brewing caldron. For crucible spoon I used the word for mixing spoon instead of `tiegellöffel`, as tiegellöffel would make next to no sense in german.

The reason for this flaw is adherent to the english language file, from which I based the translation off.